### PR TITLE
Add support for nested MultiValidator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.2]
+
+- Add support for nested multi validator.
+
 ## [1.0.1]
 ### fix intl dependency conflict
 ### add usage example

--- a/lib/form_field_validator.dart
+++ b/lib/form_field_validator.dart
@@ -162,7 +162,9 @@ class MultiValidator extends FieldValidator<String?> {
   @override
   bool isValid(value) {
     for (FieldValidator validator in validators) {
-      if (validator.call(value) != null) {
+      if (validator is MultiValidator) {
+        if (!validator.isValid(value)) return false;
+      } else if (validator.call(value) != null) {
         _errorText = validator.errorText;
         return false;
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: form_field_validator
 description: A straightforward flutter form field validator that provides common validation options.
-version: 1.0.1
+version: 1.0.2
 author: Milad Akarie <milad.akarie@gmail.com>
 homepage: https://github.com/Milad-Akarie/form_field_validator
 

--- a/test/form_field_validator_test.dart
+++ b/test/form_field_validator_test.dart
@@ -169,5 +169,26 @@ void main() {
         expect(null, nonRequiredMultiValidator('short text'));
       });
     });
+
+    group('Nested MultiValidator with required validator', () {
+      final multiValidator = MultiValidator([
+        MultiValidator([
+          RequiredValidator(errorText: requiredErrorText),
+          MaxLengthValidator(15, errorText: maxLengthErrorText),
+        ])
+      ]);
+
+      test('calling validate with an empty value will return $requiredErrorText', () {
+        expect(requiredErrorText, multiValidator(''));
+      });
+
+      test('calling validate with a string > 15 charecters will return $maxLengthErrorText', () {
+        expect(maxLengthErrorText, multiValidator('a long text that contains more than 15 chars'));
+      });
+
+      test('calling validate with a string <= 15 charecters will return null', () {
+        expect(null, multiValidator('short text'));
+      });
+    });
   });
 }


### PR DESCRIPTION
Adding support for nested `MultiValidator` for example:

```dart
// ..
final requiredEmail = MultiValidator([
  RequiredValidator(errorText: 'Email is required'),
  EmailValidator(errorText: 'Email is wrong'),
]);

TextFormField(
  validator: MultiValidator([
    requiredEmail,
    PatternValidator(r'<MY_PATTERN>', errorText: 'Wrong email'),
  ]),
);
// ..
```

It doesn't work because `MultiValidator` doesn't loop throw nested `FieldValidator`.

With this PR we we already check if there's nested elements there to loop through them.