### PR TITLE
Make all validators (except `RequiredValidator`) to accept empty values by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [2.0.0]
+All validators have `required: bool` argument which defaults to `false` so empty
+values are fine for all validators except `RequiredValidator` which has `required: true`
+for obvious reason.
+This may break some codes where value is required by default. To achieve this pass
+either `required: true` when creating the validator or use `MultiValidator` with
+`RequiredValidator` and any other. See README.md for examples.
+
+If you have your own validator(s) and override the `ignoreEmptyValues` getter, remove 
+this getter as it doesn't exist in `TextFieldValidator` anymore and replace this with
+`required` argument passed to `super()` constructor. See README.md for examples.
+
 ## [1.0.1]
 ### fix intl dependency conflict
 ### add usage example

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # form_field_validator  
   
-A straightforward flutter form field validator that provides common validation options.  
+A straightforward flutter form field validator that provides common validation options.
   
 ## Usage  
   
@@ -9,20 +9,34 @@ A straightforward flutter form field validator that provides common validation o
      // assign it directly to a TextFormField validator  
      // you don't have the pass the value your self like  
      // validator: (value) => EmailValidator(errorText: 'invalid email address').call(value)  
-       
+
+     // accepts empty value
      TextFormField(  
          validator: EmailValidator(errorText: 'enter a valid email address')  
          );  
-   
+
+     // require a value   
+     TextFormField(  
+         validator: EmailValidator(errorText: 'enter a valid email address', required: true)  
+         );  
+
      // create a reusable instance  
      final requiredValidator = RequiredValidator(errorText: 'this field is required');  
      
      // again assign it directly to the validator  
      TextFormField(validator: requiredValidator);  
      
-```  
+```
+*Note that all validators (except `RequiredValidator`) accept empty values by default from
+version 2.0.0.*
+
+To require a value, either pass `required: true` argument to validator's constructor or
+use `MutliValidator`
   
-## Multi rules validation   
+## Multi rules validation
+
+Use this to combine multiple validators. When you require a value, add `RequiredValidator`
+as all other validators do not require a value by default.
 
 ```dart  
    
@@ -57,39 +71,33 @@ A straightforward flutter form field validator that provides common validation o
 ```dart  
    
 class LYDPhoneValidator extends TextFieldValidator {  
-  // pass the error text to the super constructor  
-  LYDPhoneValidator({String errorText = 'enter a valid LYD phone number'}) : super(errorText);  
+    // pass the error text and the `required` flag to the super constructor   
+    LYDPhoneValidator({
+        String errorText = 'enter a valid LYD phone number',
+        bool? required})
+    : super(errorText, required: required);  
   
-  // return false if you want the validator to return error  
-  // message when the value is empty.  
-  @override  
-   bool get ignoreEmptyValues => true;  
-    
-	  @override  
-	  bool isValid(String value) {  
-	    // return true if the value is valid according the your condition  
-	    return hasMatch(r'^((+|00)?218|0?)?(9[0-9]{8})$', value);  
-	  }  
+    @override  
+    bool isValid(String value) {  
+    // return true if the value is valid according the your condition  
+    return hasMatch(r'^((+|00)?218|0?)?(9[0-9]{8})$', value);  
+    }  
 }  
 
+// use it by assigning it to the TextFormField validator  
+TextFormField(validator: LYDPhoneValidator());  
 
-   // use it by assigning it to the TextFormField validator  
-   TextFormField(validator: LYDPhoneValidator());  
 
-
-  
   
 // you can also extend the base FieldValidator class   
 // to work with non string values  
-  
 class CustomValidator extends FieldValidator<T>{  
-   CustomValidator(String errorText) : super(errorText);  
-  
-	  @override  
-	  bool isValid(T value) {  
-	    // TODO: implement isValid  
-	    return //condition;
-	  }  
-  }  
-  
+    CustomValidator(String errorText) : super(errorText);  
+    
+    @override  
+    bool isValid(T value) {  
+        // TODO: implement isValid  
+        return //condition;
+    }  
+}  
  ```

--- a/lib/form_field_validator.dart
+++ b/lib/form_field_validator.dart
@@ -1,6 +1,5 @@
 library form_field_validator;
 
-import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 
 /// same function signature as FormTextField's validator;
@@ -23,27 +22,23 @@ abstract class FieldValidator<T> {
 }
 
 abstract class TextFieldValidator extends FieldValidator<String?> {
-  TextFieldValidator(String errorText) : super(errorText);
+  final bool _required;
 
-  // return false if you want the validator to return error
-  // message when the value is empty.
-  bool get ignoreEmptyValues => true;
+  TextFieldValidator(String errorText, {bool? required})
+      : _required = required ?? false,
+        super(errorText);
 
   @override
   String? call(String? value) {
-    return (ignoreEmptyValues && value!.isEmpty) ? null : super.call(value);
+    return (!_required && value!.isEmpty) ? null : super.call(value);
   }
 
   /// helper function to check if an input matches a given pattern
-  bool hasMatch(String pattern, String input, {bool caseSensitive: true}) =>
-      RegExp(pattern, caseSensitive: caseSensitive).hasMatch(input);
+  bool hasMatch(String pattern, String input, {bool caseSensitive: true}) => RegExp(pattern, caseSensitive: caseSensitive).hasMatch(input);
 }
 
 class RequiredValidator extends TextFieldValidator {
-  RequiredValidator({required String errorText}) : super(errorText);
-
-  @override
-  bool get ignoreEmptyValues => false;
+  RequiredValidator({required String errorText}) : super(errorText, required: true);
 
   @override
   bool isValid(String? value) {
@@ -59,7 +54,7 @@ class RequiredValidator extends TextFieldValidator {
 class MaxLengthValidator extends TextFieldValidator {
   final int max;
 
-  MaxLengthValidator(this.max, {required String errorText}) : super(errorText);
+  MaxLengthValidator(this.max, {required String errorText, bool? required}) : super(errorText, required: required);
 
   @override
   bool isValid(String? value) {
@@ -70,10 +65,7 @@ class MaxLengthValidator extends TextFieldValidator {
 class MinLengthValidator extends TextFieldValidator {
   final int min;
 
-  MinLengthValidator(this.min, {required String errorText}) : super(errorText);
-
-  @override
-  bool get ignoreEmptyValues => false;
+  MinLengthValidator(this.min, {required String errorText, bool? required}) : super(errorText, required: required);
 
   @override
   bool isValid(String? value) {
@@ -85,11 +77,8 @@ class LengthRangeValidator extends TextFieldValidator {
   final int min;
   final int max;
 
-  @override
-  bool get ignoreEmptyValues => false;
-
-  LengthRangeValidator({required this.min, required this.max, required String errorText})
-      : super(errorText);
+  LengthRangeValidator({required this.min, required this.max, required String errorText, bool? required})
+      : super(errorText, required: required);
 
   @override
   bool isValid(String? value) {
@@ -101,8 +90,7 @@ class RangeValidator extends TextFieldValidator {
   final num min;
   final num max;
 
-  RangeValidator({required this.min, required this.max, required String errorText})
-      : super(errorText);
+  RangeValidator({required this.min, required this.max, required String errorText, bool? required}) : super(errorText, required: required);
 
   @override
   bool isValid(String? value) {
@@ -120,7 +108,7 @@ class EmailValidator extends TextFieldValidator {
   final Pattern _emailPattern =
       r"^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$";
 
-  EmailValidator({required String errorText}) : super(errorText);
+  EmailValidator({required String errorText, bool? required}) : super(errorText, required: required);
 
   @override
   bool isValid(String? value) => hasMatch(_emailPattern.toString(), value!, caseSensitive: false);
@@ -130,8 +118,8 @@ class PatternValidator extends TextFieldValidator {
   final Pattern pattern;
   final bool caseSensitive;
 
-  PatternValidator(this.pattern, {required String errorText, this.caseSensitive = true})
-      : super(errorText);
+  PatternValidator(this.pattern, {required String errorText, this.caseSensitive = true, bool? required})
+      : super(errorText, required: required);
 
   @override
   bool isValid(String? value) => hasMatch(pattern.toString(), value!, caseSensitive: caseSensitive);
@@ -140,7 +128,7 @@ class PatternValidator extends TextFieldValidator {
 class DateValidator extends TextFieldValidator {
   final String format;
 
-  DateValidator(this.format, {required String errorText}) : super(errorText);
+  DateValidator(this.format, {required String errorText, bool? required}) : super(errorText, required: required);
 
   @override
   bool isValid(String? value) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -99,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: form_field_validator
 description: A straightforward flutter form field validator that provides common validation options.
-version: 1.0.1
+version: 2.0.0
 author: Milad Akarie <milad.akarie@gmail.com>
 homepage: https://github.com/Milad-Akarie/form_field_validator
 


### PR DESCRIPTION
To require a value, either pass `required: true` argument to validator's constructor oruse `MutliValidator`.
This way it's possible to easily specify whether the value is required or not.